### PR TITLE
Makefile: Add go1.15.* to allowed go version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,10 @@ check_go_version:
 	case "$$OUTPUT" in \
 	*"go1.13."*);; \
 	*"go1.14."*);; \
+	*"go1.15."*);; \
 	*"devel"*);; \
 	*) \
-		echo "Expected: go version go1.13.*, go1.14.*, or devel"; \
+		echo "Expected: go version go1.13.*, go1.14.*, go1.15.*, or devel"; \
 		echo "Found:    $$OUTPUT"; \
 		exit 1; \
 	;; \


### PR DESCRIPTION
As Kubernetes has switched to go version 1.15, most of the developers
have 1.15 go version locally.

I tested this and it all worked correctly for me using go1.15.2 locally.